### PR TITLE
Revert "added conference"

### DIFF
--- a/siddpubs-conf.bib
+++ b/siddpubs-conf.bib
@@ -45,15 +45,6 @@
 @string{corl = "Conference on Robot Learning"}
 @string{icaps = "International Conference on Automated Planning and Scheduling"}
 
-% 2018 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-@inproceedings{chen2018trust,
- title={Planning with Trust for Human-Robot Collaboration},
-  author={Chen$^{*}$, Min and Nikolaidis$^{*}$, Stefanos and Soh, Harold and Hsu, David and Srinivasa, Siddhartha},
- booktitle=hri,
- year={2018},
- note={{$^{*}$ equal contribution, \textbf{Best Conference Paper Award Finalist}}}
-}
-
 % 2017 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 @inproceedings{choudhury2017active,


### PR DESCRIPTION
Reverts personalrobotics/pubs#5.

It uses some LaTeX that I didn't add website support for. I'll try to take a look at it tomorrow.