### PR TITLE
arxiv PDF for LRA* with icaps reference

### DIFF
--- a/siddpubs-conf.bib
+++ b/siddpubs-conf.bib
@@ -68,7 +68,7 @@
  year={2018}
 }
 
-@inproceedings{mandalika2018lrastar,
+@inproceedings{mandalika2018lrastarfull,
  title={{Lazy Receding Horizon A* for Efficient Path Planning in Graphs with Expensive-to-Evaluate Edges}},
  author={Mandalika, A. and Salzman, O. and Srinivasa, S.S.},
  booktitle=icaps,

--- a/siddpubs-misc.bib
+++ b/siddpubs-misc.bib
@@ -40,14 +40,6 @@
 @string{iitm = "Mechanical Engineering, Indian Institute of Technology Madras"}
 @string{ijrr-data = "The International Journal of Robotics Research (Data Paper)"}
 
-@misc{mandalika2018lrastarfull,
-  title={{Lazy Receding Horizon A* for Efficient Path Planning in Graphs with Expensive-to-Evaluate Edges}},
-  author={Mandalika, A. and Salzman, O. and Srinivasa, S.S},
-  year={2018},
-  Eprint={arXiv:1803.04998},
-  note={(Extended version of paper at ICAPS 2018.)}
-}
-
 @article{calli2017ycb-data,
   title={{Y}ale-{CMU}-{B}erkeley dataset for robotic manipulation research},
   author={Calli, B. and Singh, A. and Bruce, J. and W. Aaron, W. and Konolige, K. and Srinivasa, S.S. and Abbeel, P. and Dollar, A.M.},


### PR DESCRIPTION
Removes the temporary entry in `misc` and changes the PDF pointed to by the `conf` entry.

- [x] Update `.bib` file
- [x] Upload publication PDF to [Google Drive](https://drive.google.com/drive/folders/1M9fOGIIQ3e1R62dtVit5rZ5iWZqxfWV9)
