### PR TITLE
ICML paper

### DIFF
--- a/siddpubs-conf.bib
+++ b/siddpubs-conf.bib
@@ -21,6 +21,8 @@
 @string{corl = "{CORL}"}
 @string{icaps = "{ICAPS}"}
 @string{ijcai = "{IJCAI}"}
+@string{icml = "{ICML}"}
+
 
 % Long conference names
 @string{aaai = "{AAAI} Conference on Artificial Intelligence"}
@@ -46,8 +48,17 @@
 @string{corl = "Conference on Robot Learning"}
 @string{icaps = "International Conference on Automated Planning and Scheduling"}
 @string{ijcai = "International Joint Conference on Artificial Intelligence"}
+@string{icml = "International Conference on Machine Learning"}
+
 
 % 2018 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+@inproceedings{hefny2018rpsp,
+  title={Recurrent Predictive State Policy Networks},
+  author={Hefny, A. and Marinho, Z. and Sun, W. and Srinivasa, S.S. and Gordon, G.},
+  booktitle=icml,
+  year={2018}
+}
+
 @inproceedings{choudhury2018bayesian,
   title={Bayesian Active Edge Evaluation on Expensive Graphs},
   author={Choudhury, S. and Srinivasa, S.S. and Scherer, S.},


### PR DESCRIPTION
Added new ICML paper on Recurrent Predictive State Policy Networks.

- [x] Update `.bib` file
- [x] Upload publication PDF to [Google Drive](https://drive.google.com/drive/folders/1M9fOGIIQ3e1R62dtVit5rZ5iWZqxfWV9)
