### PR TITLE
Add gordon2021posthoc to conference pubs

### DIFF
--- a/siddpubs-conf.bib
+++ b/siddpubs-conf.bib
@@ -61,6 +61,15 @@
 @string{acc = "American Controls Conference"}
 @string{ldc = "Learning for Demonstration & Control"}
 
+% 2021 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@inproceedings{gordon2021posthoc,
+ title = {{Leveraging Post Hoc Context for Faster Learning in Bandit Settings with Applications in Robot-Assisted Feeding}},
+ author = {Gordon, E.K. and Roychowdhury, S. and Bhattacharjee, T. and Jamieson, K. and Srinivasa, S.S.},
+ booktitle = icra,
+ year = {2021},
+}
+
 % 2020 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 @inproceedings{roh2020trajpred,


### PR DESCRIPTION
Camera-ready paper uploaded to Google Drive

- [x] Update `.bib` file
- [x] Upload publication PDF to [Google Drive](https://drive.google.com/drive/folders/1M9fOGIIQ3e1R62dtVit5rZ5iWZqxfWV9)
