### PR TITLE
Update siddpubs-misc.bib

### DIFF
--- a/siddpubs-misc.bib
+++ b/siddpubs-misc.bib
@@ -52,14 +52,6 @@
   year = {2021}
 }
 
-@article{mavrogiannis2020unsignalized,
-  title = {Implicit Multiagent Coordination at Unsignalized Intersections via Multimodal Inference Enabled by Topological Braids},
-  author = {Mavrogiannis, C. and DeCastro, J. A. and Srinivasa, S. S.},
-  journal = {CoRR},
-  volume = {abs/2004.05205},
-  year = {2020}
-}
-
 @inproceedings{lee2019packing,
   title = {Towards Effective Human-AI Teams: The Case of Collaborative Packing},
   author = {Lee, G. and Mavrogiannis, C. and Srinivasa, S.S.},


### PR DESCRIPTION
wafr paper replaces tech report from 2020

- [ x] Update `.bib` file
- [ x] Upload publication PDF to [Google Drive](https://drive.google.com/drive/folders/1M9fOGIIQ3e1R62dtVit5rZ5iWZqxfWV9)
