### PR TITLE
Add Expanded Action Space Dataset

### DIFF
--- a/siddpubs-misc.bib
+++ b/siddpubs-misc.bib
@@ -44,8 +44,19 @@
 @string{nips      = "Conference on Neural Information Processing Systems"}
 @string{ahri      = "AAAI Fall Symposium on Artificial Intelligence and Human-Robot Interaction"}
 
+@misc{nanavati2022dataset,
+  author = {Nanavati, A. and Challa, R. and Gordon, E. K. and Srinivasa, S. S.},
+  title = {A Dataset of Food Manipulation Strategies for Diverse Foods},
+  publisher = {Harvard Dataverse},
+  UNF = {UNF:6:xTl7JCqFdRxjq1GxXecZ+g==},
+  year = {2022},
+  version = {V1},
+  doi = {10.7910/DVN/C8SI1D},
+  url = {https://doi.org/10.7910/DVN/C8SI1D}
+}
+
 @article{mavrogiannis2021tmpc,
-  author = {Mavrogiannis, C and Balasubramanian, K and Poddar, S. and Gandra, A. and Srinivasa, S. S.},
+  author = {Mavrogiannis, C. and Balasubramanian, K. and Poddar, S. and Gandra, A. and Srinivasa, S. S.},
   title = {Topology-Informed Model Predictive Control for Anticipatory Collision Avoidance on a Ballbot},
   journal = {CoRR},
   volume = {abs/2109.05084},


### PR DESCRIPTION
https://doi.org/10.7910/DVN/C8SI1D

(I believe since I included the URL, [optional_publink](https://github.com/personalrobotics/prl-website/blob/c4a6ef09f22ed559073d56078a995c8714503ff5/personalrobotics/main/publications.py#L93) from the website code should use that instead of searching in Google Drive)

- [x] Update `.bib` file
- [N/A] Upload publication PDF to [Google Drive](https://drive.google.com/drive/folders/1M9fOGIIQ3e1R62dtVit5rZ5iWZqxfWV9)
