### PR TITLE
Add HRI23 Video Submission

### DIFF
--- a/siddpubs-misc.bib
+++ b/siddpubs-misc.bib
@@ -50,7 +50,7 @@
   booktitle = hri,
   year = {2023},
   url = {https://www.youtube.com/watch?v=02LYORrcN7M},
-  note = {PDF \href{here}{https://personalrobotics.cs.washington.edu/publications/nanavati2023unintended.pdf}}
+  note = {PDF {\href{here}{https://personalrobotics.cs.washington.edu/publications/nanavati2023unintended.pdf}}}
 }
 
 @inproceedings{lee2019packing,

--- a/siddpubs-misc.bib
+++ b/siddpubs-misc.bib
@@ -50,6 +50,7 @@
   booktitle = hri,
   year = {2023},
   url = {https://www.youtube.com/watch?v=02LYORrcN7M},
+  note = {PDF \href{here}{https://personalrobotics.cs.washington.edu/publications/nanavati2023unintended.pdf}}
 }
 
 @inproceedings{lee2019packing,

--- a/siddpubs-misc.bib
+++ b/siddpubs-misc.bib
@@ -44,6 +44,14 @@
 @string{nips      = "Conference on Neural Information Processing Systems"}
 @string{ahri      = "AAAI Fall Symposium on Artificial Intelligence and Human-Robot Interaction"}
 
+@inproceedings{nanavati2023unintended,
+  title = {Unintended Failures of Robot-Assisted Feeding in Social Contexts},
+  author = {Nanavati, A. and Alves-Oliveira, P. and Schrenk, T. and Gordon, E.K. and Cakmak, M. and Srinivasa, S. S.},
+  booktitle = hri,
+  year = {2023},
+  url = {https://www.youtube.com/watch?v=02LYORrcN7M},
+}
+
 @inproceedings{lee2019packing,
   title = {Towards Effective Human-AI Teams: The Case of Collaborative Packing},
   author = {Lee, G. and Mavrogiannis, C. and Srinivasa, S.S.},


### PR DESCRIPTION
NOTE: This submission is technically both a YouTube video and a 2 page paper. I don't think we currently have the capability to add two links to the website. I've linked the video from the to the BibTex file, and added the the paper to the Google Drive https://drive.google.com/file/d/1ciXbUttJz3bR-FJq9dKXFtsFvjqxp70c/view?usp=sharing , but the paper isn't currently linked from the website.

LMK if you have suggestions on getting both links reflected.

- [X] Update `.bib` file
- [?] Upload publication PDF to [Google Drive](https://drive.google.com/drive/folders/1M9fOGIIQ3e1R62dtVit5rZ5iWZqxfWV9)
