### PR TITLE
Add workshop paper HRI 2023

### DIFF
--- a/siddpubs-misc.bib
+++ b/siddpubs-misc.bib
@@ -53,6 +53,13 @@
   note = {PDF {\href{here}{https://personalrobotics.cs.washington.edu/publications/nanavati2023unintended.pdf}}}
 }
 
+@inproceedings{karim2023autonomy,
+  title = {Investigating the Levels of Autonomy for Personalization in Assistive Robotics},
+  author = {Karim, R. and Nanavati, A. and Faulkner, T.A.K. and Srinivasa, S. S.},
+  booktitle = hri,
+  year = {2023}
+}
+
 @inproceedings{lee2019packing,
   title = {Towards Effective Human-AI Teams: The Case of Collaborative Packing},
   author = {Lee, G. and Mavrogiannis, C. and Srinivasa, S.S.},


### PR DESCRIPTION
- [x] Update `.bib` file
- [x] Upload publication PDF to [Google Drive](https://drive.google.com/drive/folders/1M9fOGIIQ3e1R62dtVit5rZ5iWZqxfWV9)
