### PR TITLE
Pubs Updates from HRI24

### DIFF
--- a/siddpubs-misc.bib
+++ b/siddpubs-misc.bib
@@ -54,7 +54,7 @@
 
 @inproceedings{gordonjenamaninanavati2024demo,
   title = {An Adaptable, Safe, and Portable Robot-Assisted Feeding System},
-  author = {Gordon$^{*}$, E.K. and Janamani$^{*}$, R.K. and Nanavati$^{*}$, A. and Liu, Z. and Bolotski, H. and Karim, R. and Stabile, D. and Kashyap, A. and Zhu, B. H. and Dai, X. and Schrenk, T. and Ko, J. and Faulkner, T.A.K. and Bhattacharjee, T. and Srinivasa, S.S.},
+  author = {Gordon$^{*}$, E.K. and Jenamani$^{*}$, R.K. and Nanavati$^{*}$, A. and Liu, Z. and Bolotski, H. and Karim, R. and Stabile, D. and Kashyap, A. and Zhu, B. H. and Dai, X. and Schrenk, T. and Ko, J. and Faulkner, T.A.K. and Bhattacharjee, T. and Srinivasa, S.S.},
   booktitle = hri,
   year = {2024},
   note = {{\textbf{Best Demo Award Winner}}}

--- a/siddpubs-misc.bib
+++ b/siddpubs-misc.bib
@@ -44,17 +44,25 @@
 @string{nips      = "Conference on Neural Information Processing Systems"}
 @string{ahri      = "AAAI Fall Symposium on Artificial Intelligence and Human-Robot Interaction"}
 
-@inproceedings{gordonjenamaninanavati2024demo,
-  title = {An Adaptable, Safe, and Portable Robot-Assisted Feeding System},
-  author = {Gordon$^{*}$, E.K. and Janamani$^{*}$, R.K. and Nanavati$^{*}$, A. and Liu, Z. and Bolotski, H. and Karim, R. and Stabile, D. and Kashyap, A. and Zhu, B. H. and DAi, X. and Schrenk, T. and Ko, J. and Bhattacharjee, T. and Srinivasa, S. S.},
+@inproceedings{nanavati2024multiple,
+  title = {Multiple Ways of Working with Users to Develop Physically Assistive Robots},
+  author = {Nanavati$^{*}$, A. and Pascher$^{*}$, M. and Ranganeni, V. and Gordon, E.K. and Faulkner, T.A.K. and Srinivasa, S.S. and Cakmak, M. and Alves-Oliveira, P. and Gerken, J.},
   booktitle = hri,
   year = {2024},
-  note = {Demo Track}
+  note = {Workshop on Assistive Applications, Accessibility, and Disability Ethics}
+}
+
+@inproceedings{gordonjenamaninanavati2024demo,
+  title = {An Adaptable, Safe, and Portable Robot-Assisted Feeding System},
+  author = {Gordon$^{*}$, E.K. and Janamani$^{*}$, R.K. and Nanavati$^{*}$, A. and Liu, Z. and Bolotski, H. and Karim, R. and Stabile, D. and Kashyap, A. and Zhu, B. H. and Dai, X. and Schrenk, T. and Ko, J. and Faulkner, T.A.K. and Bhattacharjee, T. and Srinivasa, S.S.},
+  booktitle = hri,
+  year = {2024},
+  note = {{\textbf{Best Demo Award Winner}}}
 }
 
 @inproceedings{nanavati2023unintended,
   title = {Unintended Failures of Robot-Assisted Feeding in Social Contexts},
-  author = {Nanavati, A. and Alves-Oliveira, P. and Schrenk, T. and Gordon, E.K. and Cakmak, M. and Srinivasa, S. S.},
+  author = {Nanavati, A. and Alves-Oliveira, P. and Schrenk, T. and Gordon, E.K. and Cakmak, M. and Srinivasa, S.S.},
   booktitle = hri,
   year = {2023},
   url = {https://www.youtube.com/watch?v=02LYORrcN7M},
@@ -63,7 +71,7 @@
 
 @inproceedings{karim2023autonomy,
   title = {Investigating the Levels of Autonomy for Personalization in Assistive Robotics},
-  author = {Karim, R. and Nanavati, A. and Faulkner, T.A.K. and Srinivasa, S. S.},
+  author = {Karim, R. and Nanavati, A. and Faulkner, T.A.K. and Srinivasa, S.S.},
   booktitle = hri,
   year = {2023}
 }


### PR DESCRIPTION
This PR adds the HRI24 workshop paper ([Google Drive link](https://drive.google.com/file/d/1MnahUbPeUXNuPm5sWNvK-TNYcY28OTgJ/view?usp=drive_link)), adds that we won Best Demo. and makes other small updates. 

- [x] Update `.bib` file
- [x] Upload publication PDF to [Google Drive](https://drive.google.com/drive/folders/1M9fOGIIQ3e1R62dtVit5rZ5iWZqxfWV9)
