### PR TITLE
Remove Note from HRI'25 paper

### DIFF
--- a/siddpubs-conf.bib
+++ b/siddpubs-conf.bib
@@ -69,8 +69,7 @@
   author={Nanavati, Amal and Gordon, Ethan K and Kessler Faulkner, Taylor A and Song, Yuxin (Ray) and Ko, Johnathan and Schrenk, Tyler and Nguyen, Vy and Zhu, Bernie Hao and Bolotski, Haya and Kashyap, Atharva and Kutty, Sriram and Karim, Raida and Rainbolt, Liander and Scalise, Rosario and Song, Hanjun and Qu, Ramon and Cakmak, Maya and Srinivasa, Siddhartha S},
   booktitle = hri,
   year={2025},
-  url={https://robotfeeding.io/publications/hri25a/},
-  note = {{\href{Website}{https://robotfeeding.io/publications/hri25a/}}}
+  url={https://robotfeeding.io/publications/hri25a/}
 }
 
 % 2024 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Although #111 added the HRI paper, it rendered redundantly on the website:

1. Because it specified the `url` field, the link on the title went to the paper's website instead of the PDF.
2. Because it specified the `note` field, a link to the website also appeared below the paper's citation.

Upon discussion with @adlarkin,  we agreed that having the paper title link to the website is better than having a separate note below the paper. Thus, this PR removes the `note` field of this pub.

Policy for linking to a website instead of a paper PDF:
1. Ensure the website is permanently hosted (i.e., it shouldn't be affiliated with an account that could get deactivated).
2. Ensure the website links to the paper within the `personalrobotics.cs.washington.edu` domain (e.g., https://personalrobotics.cs.washington.edu/publications/nanavati2025lessons.pdf ).
3. Specify the `url` field in the bibtex to override the title link.
