### PR TITLE
Replace URL with Note for HRI'25 paper

### DIFF
--- a/siddpubs-conf.bib
+++ b/siddpubs-conf.bib
@@ -69,7 +69,7 @@
   author={Nanavati, Amal and Gordon, Ethan K and Kessler Faulkner, Taylor A and Song, Yuxin (Ray) and Ko, Johnathan and Schrenk, Tyler and Nguyen, Vy and Zhu, Bernie Hao and Bolotski, Haya and Kashyap, Atharva and Kutty, Sriram and Karim, Raida and Rainbolt, Liander and Scalise, Rosario and Song, Hanjun and Qu, Ramon and Cakmak, Maya and Srinivasa, Siddhartha S},
   booktitle = hri,
   year={2025},
-  url={https://robotfeeding.io/publications/hri25a/}
+  note = {{\href{Website}{https://robotfeeding.io/publications/hri25a/}}}
 }
 
 % 2024 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Following a discussion in Slack, we decided to settle on the norm that the title URL always points to the paper PDF (with the rare exception of non-textual publications like videos or datasets), and paper websites are linke din the Notes section. As such, this PR removes the `url` field from the bibtex entry, instead linking the website from `notes`.
