### PR TITLE
Add publication guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ synced to the web server.
 [prl-pubs]: https://personalrobotics.cs.washington.edu/publications/
 [prl-drive]: https://drive.google.com/drive/folders/1M9fOGIIQ3e1R62dtVit5rZ5iWZqxfWV9
 
+## Guidelines
+
+- The publication title URL should point to the paper PDF on the personalrobotics domain.
+- The rare exception is non-textual publications, such as videos or datasets: [example](https://github.com/personalrobotics/pubs/blob/e70ceab48d07c2efdaa4a071256fd8c1e17e861f/siddpubs-misc.bib#L68-L69).
+- If the publication has a project website, the website can be linked as a `note` in the BibTex: [example](https://github.com/personalrobotics/pubs/blob/e70ceab48d07c2efdaa4a071256fd8c1e17e861f/siddpubs-conf.bib#L72).
+  The project website should have a link to the paper PDF on the personalrobotics domain.
+
 ## Adding this repo to a LaTeX paper repo
 
 One way to add this repository to a paper repository is via the [git submoudle](https://git-scm.com/book/en/v2/Git-Tools-Submodules) command. Do the following in your paper repository:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ synced to the web server.
 - The rare exception is non-textual publications, such as videos or datasets: [example](https://github.com/personalrobotics/pubs/blob/e70ceab48d07c2efdaa4a071256fd8c1e17e861f/siddpubs-misc.bib#L68-L69).
 - If the publication has a project website, the website can be linked as a `note` in the BibTex: [example](https://github.com/personalrobotics/pubs/blob/e70ceab48d07c2efdaa4a071256fd8c1e17e861f/siddpubs-conf.bib#L72).
   The project website should have a link to the paper PDF on the personalrobotics domain.
+  The website should also be persistent (i.e., on a web domain or resource that will outlive your time in the lab and that other lab members can access if need be).
 
 ## Adding this repo to a LaTeX paper repo
 


### PR DESCRIPTION
Motivated by https://github.com/personalrobotics/pubs/pull/113

- Define rules for publication titles (default is to link to paper PDF)
- Highlight cases such as project websites and non-textual publications