### PR TITLE
Fixes href flip bug

### DIFF
--- a/siddpubs-conf.bib
+++ b/siddpubs-conf.bib
@@ -76,7 +76,7 @@
   author={Nanavati, Amal and Gordon, Ethan K and Kessler Faulkner, Taylor A and Song, Yuxin (Ray) and Ko, Johnathan and Schrenk, Tyler and Nguyen, Vy and Zhu, Bernie Hao and Bolotski, Haya and Kashyap, Atharva and Kutty, Sriram and Karim, Raida and Rainbolt, Liander and Scalise, Rosario and Song, Hanjun and Qu, Ramon and Cakmak, Maya and Srinivasa, Siddhartha S},
   booktitle = hri,
   year={2025},
-  note = {{\href{Website, Best Systems Paper Award Finalist}{https://robotfeeding.io/publications/hri25a/}}}
+  note = {{\href{https://robotfeeding.io/publications/hri25a/}{Website, Best Systems Paper Award Finalist}}}
 }
 
 % 2024 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/siddpubs-misc.bib
+++ b/siddpubs-misc.bib
@@ -66,7 +66,7 @@
   booktitle = hri,
   year = {2023},
   url = {https://www.youtube.com/watch?v=02LYORrcN7M},
-  note = {PDF {\href{here}{https://personalrobotics.cs.washington.edu/publications/nanavati2023unintended.pdf}}}
+  note = {PDF {\href{https://personalrobotics.cs.washington.edu/publications/nanavati2023unintended.pdf}{here}}}
 }
 
 @inproceedings{karim2023autonomy,


### PR DESCRIPTION
This is related to [Issue 251](https://github.com/personalrobotics/prl-website/issues/251) on the prl-website. Standard LaTeX convention is to use `\href{link}{text}`.