### PR TITLE
Update Python version to 3.12 in workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: '3.12'
         cache: pip
         cache-dependency-path: prl-website/setup.py
     - name: Install PRL website


### PR DESCRIPTION
This is a temporary fix for the issue caused by Python 3.14 dropping compatibility with ast.Str leading to the test-pubs action failing. The correct long-term solution is to update the dep's and/or write a better app.

The website built through the UW CSE cycle server uses Python 3.9 for its environment, so it might be worthwhile to force the test environment to match the version we actually use for deployment, whatever that version is.